### PR TITLE
Adding special treatment to % in price strings

### DIFF
--- a/src/components/Syntax.vue
+++ b/src/components/Syntax.vue
@@ -33,7 +33,7 @@ export default {
   color: rgb(0, 191, 161);
 }
 
-::v-deep .maths {
+::v-deep .maths, ::v-deep .percent {
   color: rgb(38, 145, 211);
 }
 

--- a/src/lib/stylizer.js
+++ b/src/lib/stylizer.js
@@ -12,6 +12,9 @@ const REG_MATH_REPLACEMENTS = [
   [/-/g, '-'],
   [/\*/g, '*'],
   [/\+/g, '+'],
+];
+
+const REG_PERCENT_REPLACEMENTS = [
   [/%/g, '%'],
 ];
 
@@ -89,6 +92,11 @@ function stylizer(func) {
     REG_MATH_REPLACEMENTS.forEach((n) => {
       const [reg, replace] = n;
       replacedString = replacedString.replace(reg, func(['maths'], replace));
+    });
+
+    REG_PERCENT_REPLACEMENTS.forEach((n) => {
+      const [reg, replace] = n;
+      replacedString = replacedString.replace(reg, func(['percent'], replace));
     });
 
     REG_ITEMS.forEach((regex) => {

--- a/tests/unit/lib/stylizer.spec.js
+++ b/tests/unit/lib/stylizer.spec.js
@@ -23,13 +23,21 @@ describe('reformatter', () => {
   it('pads item links with a space WITHOUT adding spaces inside the brackets', () => {
     expect(reformatter('[Bag of Tricks  with extra space there]')).toMatch(' [Bag of Tricks  with extra space there] ');
   });
+
+  it('does not add a space between a value and %', () => {
+    expect(reformatter('200% DBMarket')).toEqual('200% DBMarket');
+  });
 });
 
 describe('stylizeString', () => {
   it('correctly tags math operations', () => {
-    '+-*/%'.split('').forEach((operation) => {
+    '+-*/'.split('').forEach((operation) => {
       expect(stylizeString(`2 ${operation} 2`)).toMatch(`<span class="token numeric">2</span> <span class="token maths">${operation}</span> <span class="token numeric">2</span>`);
     });
+  });
+
+  it('correctly handles percent strings', () => {
+    expect(stylizeString('200% DBMarket')).toMatch('<span class="token numeric">200</span><span class="token percent">%</span> <span class="token symbol">DBMarket</span>');
   });
 
   it('correctly tags item strings', () => {


### PR DESCRIPTION
It should not pad with spaces like it does with other math operations. A
string like '200% DBMarket' is valid TSM syntax so the Beautify feature
should not correct it to '200 % DBMarket'.

closes #11